### PR TITLE
Don’t access the app delegate’s window property before launch has finished

### DIFF
--- a/Cashew/Application/AppDelegate.m
+++ b/Cashew/Application/AppDelegate.m
@@ -137,7 +137,6 @@
 }
 
 - (void)applicationWillFinishLaunching:(NSNotification *)notification {
-    [self.window setMovableByWindowBackground:YES];
     [[NSAppleEventManager sharedAppleEventManager] setEventHandler:self
                                                        andSelector:@selector(handleURLEvent:withReplyEvent:)
                                                      forEventClass:kInternetEventClass


### PR DESCRIPTION
I haven't been able to launch any recent build due to an unhandled exception:

```
2019-05-10 13:42:42.331687+1000 Cashew[71199:4686159] [General] An uncaught exception was raised
2019-05-10 13:42:42.331710+1000 Cashew[71199:4686159] [General] NSWindow drag regions should only be invalidated on the Main Thread!
2019-05-10 13:42:42.331768+1000 Cashew[71199:4686159] [General] (
	0   CoreFoundation                      0x00007fff3908acfd __exceptionPreprocess + 256
	1   libobjc.A.dylib                     0x00007fff6373ca17 objc_exception_throw + 48
	2   CoreFoundation                      0x00007fff390a485d -[NSException raise] + 9
	3   AppKit                              0x00007fff366d97ae -[NSWindow(NSWindow_Theme) _postWindowNeedsToResetDragMarginsUnlessPostingDisabled] + 317
	4   AppKit                              0x00007fff366e0502 -[NSView(NSInternal) _updateDragRegionForHiddenStateChange] + 73
	5   AppKit                              0x00007fff366cf673 -[NSView addSubview:] + 491
	6   AppKit                              0x00007fff36812be2 -[NSTableRowData _preparedRowViewForRow:storageHandler:] + 421
	7   AppKit                              0x00007fff36812936 -[NSTableRowData _addRowViewForVisibleRow:withPriorView:] + 295
	8   AppKit                              0x00007fff36812769 -[NSTableRowData _addRowViewForVisibleRow:withPriorRowIndex:inDictionary:withRowAnimation:] + 401
	9   AppKit                              0x00007fff36802f5b -[NSTableRowData _updateVisibleRowEntries] + 1479
	10  AppKit                              0x00007fff3702a4b0 __59-[NSTableRowData _automaticRowHeightsUpdateVisibleRowViews]_block_invoke.1378 + 97
	11  AppKit                              0x00007fff368a7609 -[NSTableRowData _keepTopRowStable:andDoWorkUntilDone:] + 534
	12  AppKit                              0x00007fff368a73e4 -[NSTableRowData _automaticRowHeightsUpdateVisibleRowViews] + 143
	13  AppKit                              0x00007fff368028cd -[NSTableRowData updateVisibleRowViews] + 258
	14  AppKit                              0x00007fff3684cc43 -[NSTableRowData prepareContentInRect:] + 88
	15  AppKit                              0x00007fff3684cbd9 -[NSTableView prepareContentInRect:] + 262
	16  AppKit                              0x00007fff3684c8af -[NSView _updateSuggestedContentRectToValue:] + 468
	17  AppKit                              0x00007fff36853479 -[NSView _prepareContentInRectIfNeeded:] + 71
	18  AppKit                              0x00007fff36853428 -[_NSViewBackingLayer NS_prepareContentRect:] + 58
	19  AppKit                              0x00007fff368533e5 -[_NSTiledLayer NS_prepareContentRect:] + 58
	20  AppKit                              0x00007fff36851b22 -[_NSTiledLayerContents update:shouldCallPrepareContent:] + 4266
	21  AppKit                              0x00007fff368507e4 -[_NSTiledLayer display] + 411
	22  QuartzCore                          0x00007fff43a7d51d _ZL16display_callbackPvS_ + 64
	23  QuartzCore                          0x00007fff43a7d47d _ZN2CA13DispatchGroup8dispatchEb + 49
	24  libdispatch.dylib                   0x0000000100dc7f1b _dispatch_client_callout + 8
	25  libdispatch.dylib                   0x0000000100dd0067 _dispatch_lane_serial_drain + 773
	26  libdispatch.dylib                   0x0000000100dd0f1b _dispatch_lane_invoke + 442
	27  libdispatch.dylib                   0x0000000100ddc4db _dispatch_workloop_worker_thread + 691
	28  libsystem_pthread.dylib             0x0000000100e41015 _pthread_wqthread + 421
	29  libsystem_pthread.dylib             0x0000000100e40e01 start_wqthread + 13
)
```

I also can't get the project to build under Xcode 10.2.x without the changes in #69, but this allows the app to launch without causing an unhandled exception.